### PR TITLE
Types: add option to specify base type of config

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,65 @@ Similarly in CI environments, the value in `$env_CI` is merged.
 
 ## API
 
-Please check out the typescript definition file: [index.d.ts](./index.d.ts) for a overwview of all the functions provided.
+Please check out the typescript definition file: [index.d.ts](./index.d.ts) for an overview of all the functions provided.
+
+### Typescript
+
+For getting types of the output types, you can define a typedef in your `config.js` file like:
+
+```js
+//config.js
+
+const config = {
+    db: {
+        password: 'abcde',
+        host: '127.0.0.1',
+    },
+};
+
+/** @typedef {typeof config} ConfigType */
+
+module.exports = config;
+```
+
+And in a global typings file in your project, like `global.d.ts`, import it and set this as the BaseConfig:
+
+```ts
+// global.d.ts
+import { ConfigType } from './config';
+
+declare global {
+  interface BaseConfig extends ConfigType {}
+}
+```
+
+This will be automatically picked by cfg. You can also modify this type with some custom keys available only through env vars:
+
+```ts
+// global.d.ts
+import { ConfigType } from './config';
+
+declare global {
+    interface BaseConfig extends ConfigType {
+       envVarOnlyKey?: string;
+    }
+}
+```
+
+Or omit the $env keys:
+
+```ts
+// global.d.ts
+import { ConfigType } from './config';
+
+type ConfigTypeOmit = Omit<ConfigType, '$env_development' | '$env_production'>;
+
+declare global {
+    interface BaseConfig extends ConfigTypeOmit {
+       envVarOnlyKey?: string;
+    }
+}
+```
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -113,21 +113,6 @@ declare global {
 }
 ```
 
-Or omit the $env keys:
-
-```ts
-// global.d.ts
-import { ConfigType } from './config';
-
-type ConfigTypeOmit = Omit<ConfigType, '$env_development' | '$env_production'>;
-
-declare global {
-    interface BaseConfig extends ConfigTypeOmit {
-       envVarOnlyKey?: string;
-    }
-}
-```
-
 ## CLI
 
 Get a value from cfg.js

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,11 @@
 interface BaseConfig {}
 
+type ExcludeEnv<B> = Omit<B, '$env_development' | '$env_test' | '$env_CI' | '$env_staging' | '$env_production'>;
+
+type ReadonlyConsts<T> = T extends (...args: any[]) => any ? T : Readonly<T>;
+
+type ConfigKeys<B> = keyof ExcludeEnv<B>;
+
 declare module '@smpx/cfg' {
 
 	/**
@@ -7,14 +13,14 @@ declare module '@smpx/cfg' {
 	 * @param key key to read, can be nested like `a.b.c`
 	 * @param defaultValue value to return if key is not found
 	 */
-	function cfg<P extends (keyof BaseConfig)>(key: P, defaultValue?: BaseConfig[P]): Readonly<BaseConfig[P]>
+	function cfg<P extends ConfigKeys<BaseConfig>>(key: P, defaultValue?: BaseConfig[P]): ReadonlyConsts<BaseConfig[P]>
 
 	/**
 	 * Reads a config value
 	 * @param key key to read, can be nested like `a.b.c`
 	 * @param defaultValue value to return if key is not found
 	 */
-	function cfg<P extends string, T = unknown>(key: P, defaultValue?: T): Readonly<T>
+	function cfg<P extends string, T = unknown>(key: P, defaultValue?: T): ReadonlyConsts<T>
 
 	namespace cfg {
 		/**
@@ -22,7 +28,7 @@ declare module '@smpx/cfg' {
 		 * @param key
 		 * @param defaultValue
 		 */
-		function get<P extends (keyof BaseConfig)>(key: P, defaultValue?: BaseConfig[P]): Readonly<BaseConfig[P]>
+		function get<P extends ConfigKeys<BaseConfig>>(key: P, defaultValue?: BaseConfig[P]): ReadonlyConsts<BaseConfig[P]>
 
 		/**
 		 * Reads a config value

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+interface BaseConfig {}
+
 declare module '@smpx/cfg' {
 
 	/**
@@ -5,7 +7,14 @@ declare module '@smpx/cfg' {
 	 * @param key key to read, can be nested like `a.b.c`
 	 * @param defaultValue value to return if key is not found
 	 */
-	function cfg<T = any>(key: string, defaultValue?: T): Readonly<T>
+	function cfg<P extends (keyof BaseConfig)>(key: P, defaultValue?: BaseConfig[P]): Readonly<BaseConfig[P]>
+
+	/**
+	 * Reads a config value
+	 * @param key key to read, can be nested like `a.b.c`
+	 * @param defaultValue value to return if key is not found
+	 */
+	function cfg<P extends string, T = unknown>(key: P, defaultValue?: T): Readonly<T>
 
 	namespace cfg {
 		/**
@@ -13,13 +22,20 @@ declare module '@smpx/cfg' {
 		 * @param key
 		 * @param defaultValue
 		 */
-		function get<T = any>(key: string, defaultValue?: T): Readonly<T>;
+		function get<P extends (keyof BaseConfig)>(key: P, defaultValue?: BaseConfig[P]): Readonly<BaseConfig[P]>
+
+		/**
+		 * Reads a config value
+		 * @param key
+		 * @param defaultValue
+		 */
+		function get<P extends string, T = unknown>(key: P, defaultValue?: T): Readonly<T>
 
 		/**
 		 * Get the whole config object
 		 * **NOTE:** Is not immutable, so don't write anything to it
 		 */
-		function _getConfig(): Readonly<{[key: string]: any}>;
+		function _getConfig(): Readonly<BaseConfig>;
 
 		/**
 		 * set values in global config

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,10 +32,10 @@ declare module '@smpx/cfg' {
 
 		/**
 		 * Reads a config value
-		 * @param key
+		 * @param key key to read, can be nested like `a.b.c`
 		 * @param defaultValue
 		 */
-		function get<P extends string, T = unknown>(key: P, defaultValue?: T): Readonly<T>
+		function get<P extends string, T = unknown>(key: P, defaultValue?: T): ReadonlyConsts<T>
 
 		/**
 		 * Get the whole config object


### PR DESCRIPTION
Closes #7 

This is still a WIP. And only works for first level of keys only.

Also changes default type from any to unknown as that is now the recommended approach