### PR TITLE
Add example config structure

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,5 @@ jsdoc.json
 out
 .travis.yml
 bench
+example
+.github

--- a/example/config.js
+++ b/example/config.js
@@ -1,0 +1,8 @@
+const config = require('./config/default');
+const test = require('./config/env/test');
+const production = require('./config/env/production');
+
+config.$env_test = test;
+config.$env_production = production;
+
+module.exports = config;

--- a/example/config/app/cron.js
+++ b/example/config/app/cron.js
@@ -1,0 +1,4 @@
+/** @type {import('../default').ConfigOverride} */
+const config = {
+	configSrc: 'cron',
+};

--- a/example/config/app/server.js
+++ b/example/config/app/server.js
@@ -1,0 +1,4 @@
+/** @type {import('../default').ConfigOverride} */
+const config = {
+	configSrc: 'server',
+};

--- a/example/config/default.js
+++ b/example/config/default.js
@@ -1,0 +1,9 @@
+const config = {
+	$privateConfigFile: `${__dirname}/app/${process.env.APP_NAME}`,
+	configSrc: 'default',
+};
+
+/** @typedef {typeof config} ConfigType */
+/** @typedef {Partial<ConfigType>} ConfigOverride */
+
+module.exports = config;

--- a/example/config/env/production.js
+++ b/example/config/env/production.js
@@ -1,0 +1,4 @@
+/** @type {import('../default').ConfigOverride} */
+const config = {
+	configSrc: 'production',
+};

--- a/example/config/env/test.js
+++ b/example/config/env/test.js
@@ -1,0 +1,4 @@
+/** @type {import('../default').ConfigOverride} */
+const config = {
+	configSrc: 'test',
+};

--- a/example/config/types.d.ts
+++ b/example/config/types.d.ts
@@ -1,0 +1,6 @@
+// global.d.ts
+import { ConfigType } from './default';
+
+declare global {
+  interface BaseConfig extends ConfigType {}
+}


### PR DESCRIPTION
## TODO:

- [ ] Document `$privateConfigFile`
- [ ] Add example folder structure with different files for each env and apps
- [ ] Example should have working types
- [ ] Add more test cases
- [ ] Could add an `init` command to cli to create this structure automatically?